### PR TITLE
Fixed bugs in auto driver

### DIFF
--- a/src/main/cpp/Drivetrain.cpp
+++ b/src/main/cpp/Drivetrain.cpp
@@ -7,10 +7,18 @@
 void Drivetrain::SetSpeeds(const frc::DifferentialDriveWheelSpeeds& speeds) {
   const auto leftFeedforward = m_feedforward.Calculate(speeds.left);
   const auto rightFeedforward = m_feedforward.Calculate(speeds.right);
+  //std::cout << "speeds: " << speeds.right << " " << speeds.left << std::endl;
+  //std::cout << "feeds: " << rightFeedforward << " " << leftFeedforward << std::endl;
+  //std::cout << "vel: " << m_rightEncoder->GetVelocity() << " " << -m_leftEncoder->GetVelocity() << std::endl;
+
   const double leftOutput = m_leftPIDController.Calculate(
-      m_leftEncoder->GetVelocity(), speeds.left.to<double>());
+      -m_leftEncoder->GetVelocity(), speeds.left.to<double>());
   const double rightOutput = m_rightPIDController.Calculate(
       m_rightEncoder->GetVelocity(), speeds.right.to<double>());
+
+  //std::cout << "outputs: " << rightOutput << " " << leftOutput << std::endl;
+  //std::cout << "voltages: " << units::volt_t{rightOutput} + rightFeedforward <<
+  // " " << units::volt_t{leftOutput} + leftFeedforward << std::endl;
 
   m_leftGroup->SetVoltage(units::volt_t{leftOutput} + leftFeedforward);
   m_rightGroup->SetVoltage(units::volt_t{rightOutput} + rightFeedforward);
@@ -18,13 +26,15 @@ void Drivetrain::SetSpeeds(const frc::DifferentialDriveWheelSpeeds& speeds) {
 
 void Drivetrain::Drive(units::meters_per_second_t xSpeed,
                        units::radians_per_second_t rot) {
+  //std::cout << "drive speed: " << xSpeed << " drive rot:" << rot << std::endl;
   SetSpeeds(m_kinematics.ToWheelSpeeds({xSpeed, 0_mps, rot}));
 }
 
 void Drivetrain::UpdateOdometry() {
+  //std::cout << "update pos: " << m_gyro->GetRotation2d().Degrees() << " "  << m_rightEncoder->GetPosition() << " " << -m_leftEncoder->GetPosition() << std::endl;
   m_odometry->Update(m_gyro->GetRotation2d(),
-                    units::meter_t(m_leftEncoder->GetPosition()),
-                    units::meter_t(m_rightEncoder->GetPosition()));
+                     units::meter_t(-m_leftEncoder->GetPosition()),
+                     units::meter_t(m_rightEncoder->GetPosition()));
 }
 
 void Drivetrain::ResetOdometry(const frc::Pose2d& pose) {
@@ -36,6 +46,5 @@ frc::Pose2d Drivetrain::GetPose() const {
 }
 
 units::angle::degree_t Drivetrain::GetRotation() {
-  //return m_gyro->GetAngle();
   return m_gyro->GetRotation2d().Degrees();
 }

--- a/src/main/include/Drivetrain.h
+++ b/src/main/include/Drivetrain.h
@@ -42,13 +42,15 @@ class Drivetrain {
     // Set the distance per pulse for the drive encoders. We can simply use the
     // distance traveled for one rotation of the wheel divided by the encoder
     // resolution.
-    m_leftEncoder->SetPositionConversionFactor(kDistancePerRotation);
-    m_rightEncoder->SetPositionConversionFactor(kDistancePerRotation);
-    m_leftEncoder->SetVelocityConversionFactor(kDistancePerRotation/60.0);
-    m_rightEncoder->SetVelocityConversionFactor(kDistancePerRotation/60.0);
+    m_leftEncoder->SetPositionConversionFactor(kDistancePerEncoderRotation);
+    m_rightEncoder->SetPositionConversionFactor(kDistancePerEncoderRotation);
+    m_leftEncoder->SetVelocityConversionFactor(kDistancePerEncoderRotation/60.0);
+    m_rightEncoder->SetVelocityConversionFactor(kDistancePerEncoderRotation/60.0);
 
     m_leftEncoder->SetPosition(0.0);
     m_rightEncoder->SetPosition(0.0);
+
+    m_leftGroup->SetInverted(true);
 
     // Instantiate gyro
     try {
@@ -58,12 +60,9 @@ class Drivetrain {
 			err_string += ex.what();
 			frc::DriverStation::ReportError(err_string.c_str());
 		}
-
-    //m_gyro->Reset();
     
     m_odometry = new frc::DifferentialDriveOdometry(m_gyro->GetRotation2d());
     std::cout << "DriveTrain pose " << m_odometry->GetPose().Rotation().Degrees() << std::endl;
-    std::cout << "DriveTrain done " << m_gyro->GetRotation2d().Degrees() << std::endl;
   }
 
   void SetSpeeds(const frc::DifferentialDriveWheelSpeeds& speeds);
@@ -76,17 +75,13 @@ class Drivetrain {
 
  private:
 
-  static constexpr double kP = 0.157; //2.77?;                                // measured
+  static constexpr double kP = 0.157; //2.77;                       // measured
   static constexpr auto   kS = 0.27_V;                              // measured
   static constexpr auto   kV = 1.53 * 1_V * 1_s / 1_m;              // measured
   static constexpr auto   kA = 0.254 * 1_V * 1_s * 1_s / 1_m;       // measured
-  static constexpr units::meter_t kTrackWidth = 0.657_m;            // measured
+  static constexpr units::meter_t kTrackWidth = 0.657_m;            // measured    
 
-  static constexpr double kWheelDiameter = 0.15;                    // meters (6 inches)
-  static constexpr auto kMaxAcceleration = 1.0_mps_sq;              // estimate
-  static constexpr units::meters_per_second_t kMaxSpeed = 3.5_mps;  // estimate
-
-  static constexpr double kDistancePerRotation = wpi::math::pi * kWheelDiameter;
+  static constexpr double kDistancePerEncoderRotation = 0.0387; // / 1.125;     // measured (meters)  
 
   frc::SpeedControllerGroup* m_leftGroup;
   frc::SpeedControllerGroup* m_rightGroup;

--- a/src/main/include/Robot.h
+++ b/src/main/include/Robot.h
@@ -82,6 +82,7 @@ class Robot : public frc::TimedRobot {
   rev::CANEncoder m_frontrightEncoder = m_frontrightMotor.GetEncoder();
   rev::CANEncoder m_backleftEncoder = m_backleftMotor.GetEncoder();
   rev::CANEncoder m_frontleftEncoder = m_frontleftMotor.GetEncoder();
+  
   frc::DifferentialDrive m_robotDrive{m_frontleftMotor, m_frontrightMotor};
  
   //hopper and shooter and turret//
@@ -128,8 +129,6 @@ class Robot : public frc::TimedRobot {
   bool m_isGathering   = false;
   bool m_hopperReverse = false;
 
-  
-
   // Limelight
   std::shared_ptr<NetworkTable> m_table = nt::NetworkTableInstance::GetDefault().GetTable("limelight-scorpio");
   double tx_OFFSET = 0.0; // old = 3.0
@@ -158,10 +157,7 @@ class Robot : public frc::TimedRobot {
   double m_txOFFSET = 2.0;
 
   // **** RAMSETE Control **** //
-  //frc::SpeedControllerGroup* m_leftGroup; //{m_frontleftMotor, m_backleftMotor};
-  //frc::SpeedControllerGroup* m_rightGroup; //{m_frontrightMotor, m_backrightMotor};
-
-  Drivetrain* m_drive; //{&m_leftGroup, &m_rightGroup, &m_frontleftEncoder, &m_frontrightEncoder};
+  Drivetrain* m_drive;
 
   // The trajectory to follow
   frc::Trajectory m_trajectory;


### PR DESCRIPTION
Scale the encoder-counts-per-revolution by the gearing ratio.
Inverted the sign of the left encoder value so that left and right sides have same sign.